### PR TITLE
Include core_foundation crate on macOS only.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 #![deny(trivial_numeric_casts, unstable_features,
         unused_import_braces, unused_qualifications)]
 
+#[cfg(target_os = "macos")]
 extern crate core_foundation;
 extern crate libc;
 


### PR DESCRIPTION
Trying to compile this on linux fails because of this.